### PR TITLE
SmqSuccess에 optional data를 추가함

### DIFF
--- a/src/main/scala/com/thing2x/smqd/SmqResult.scala
+++ b/src/main/scala/com/thing2x/smqd/SmqResult.scala
@@ -25,3 +25,5 @@ sealed trait SmqResult {
 object SmqSuccess extends SmqResult
 
 trait SmqFailure extends SmqResult
+
+case class SmqSuccessWithData(info:Map[String,String]) extends SmqResult


### PR DESCRIPTION
userDelegate를 사용해서 login 을 처리할 때, SmqSuccess와 함께 추가 정보 (role)을 보내면 좋을 것 같습니다. 
SmqSuccessWithData() case class를 추가하고, 그 정보가 access_token에 포함되도록 수정했습니다. 